### PR TITLE
fix(init): strip trailing newline when writing DB_CONNECTION to s6 env file

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-speedtest-tracker-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-speedtest-tracker-config/run
@@ -21,7 +21,7 @@ if [[ "${DB_CONNECTION:=sqlite}" = "sqlite" ]]; then
         lsiown abc:abc /app/www/database/database.sqlite
     fi
     export DB_CONNECTION=sqlite
-    echo "sqlite" > /run/s6/container_environment/DB_CONNECTION
+    printf "%s" "sqlite" > /run/s6/container_environment/DB_CONNECTION
 elif [[ "${DB_CONNECTION}" = "mysql" ]]; then
     echo "Waiting for DB to be available"
     END=$((SECONDS + 30))


### PR DESCRIPTION
## Summary

The init script writes `DB_CONNECTION` to `/run/s6/container_environment/DB_CONNECTION` using `echo`, which appends a trailing newline. s6-overlay then propagates this trailing newline into the env var seen by PHP-FPM workers. Laravel caches config via `artisan optimize` during init, so the cached `database.default` becomes `"sqlite\n"`.

At request time, any code path that resolves a DB connection (login, eloquent queries, sessions stored in DB, etc.) throws:

```
InvalidArgumentException: Database connection [sqlite
] not configured.
```

(Note the literal newline inside the brackets in the message.)

## Reproduction

1. Run the image with default env (no `/config/.env` provided, sqlite default):
   ```yaml
   services:
     speedtest-tracker:
       image: lscr.io/linuxserver/speedtest-tracker:latest
       environment:
         APP_KEY: "base64:..."
         APP_URL: http://localhost:8765
       ports:
         - "8765:80"
   ```
2. Visit `/admin/login`, enter credentials, submit.
3. With `APP_DEBUG=true` the error page shows:
   - Exception: `InvalidArgumentException`
   - Message: `Database connection [sqlite\n] not configured.`
   - Stack frame at `vendor/laravel/framework/src/Illuminate/Database/DatabaseManager.php:226`

## Fix

Replace `echo "sqlite" > /run/s6/container_environment/DB_CONNECTION` with `printf "%s" "sqlite" > ...` so the file contains exactly `sqlite` (no trailing newline).

## Verification

After applying:
- `config("database.default")` returns the 6-byte string `sqlite` (verified with `od -c`).
- Login flow completes; subsequent requests reach the dashboard with HTTP 200.
- All other code paths (queues, sessions, eloquent) work normally.

The change is one line and only affects the sqlite branch of the existing conditional. The mysql/pgsql branches were not affected.
